### PR TITLE
Error handling for JSON.parse on gpt reply

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -94,7 +94,13 @@ function parseArray(gptReply) {
   const match = gptReply.match(regex);
 
   if (match && match[1]) {
-    const functionData = JSON.parse('[' + match[1] + ']');
+    var functionData
+    try{
+      functionData = JSON.parse('[' + match[1] + ']');
+    } catch(e) {
+      console.log("Error parsing JSON:", e, "reply:", gptReply)
+      throw e
+    }    
     return functionData;
   }
 


### PR DESCRIPTION
This can fail.

For me it failed with FS files using `\` on windows and not escaping as `\\`, might fail with other improvised AI replies, better at least log the offending string.