### PR TITLE
OS friendly filename

### DIFF
--- a/modules/gpt.js
+++ b/modules/gpt.js
@@ -8,7 +8,7 @@ let totalTokensUsed = 0
 let completionTokens = 0
 let promptTokens = 0
 let cost = 0
-const logsFilename = new Date().toISOString()
+const logsFilename = new Date().toISOString().replace(/:/g, '-')
 
 
 const configuration = new Configuration({


### PR DESCRIPTION
Using `:` in filenames fails on Windows