### PR TITLE
Use path config; Fix windows paths

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -15,7 +15,7 @@ const agents = require('./agents');
 async function readAllSummaries() {
   console.log("Getting Summary");
   try {
-    const files = await fg(path.resolve(__dirname, '**/*.ai.txt'), { ignore: ignorePattern });
+    const files = await fg(path.posix.join(process.env.CODE_DIR, '**/*.ai.txt'), { ignore: ignorePattern });
     console.log("Files found:", files);
 
     if (files.length === 0) {


### PR DESCRIPTION
fast-glob expects a posix path, so we convert the path to posix before passing it to fast-glob, this is required for windows.

https://github.com/fjrdomingues/autopilot/issues/26