### PR TITLE
🤖 (auto) Issue: Review file paths in summaries

### DIFF
--- a/createSummaryOfFiles.js
+++ b/createSummaryOfFiles.js
@@ -46,8 +46,7 @@ async function processFile(dir, filePathRelative, fileContent, model) {
     const output = await fileSummary(fileContent,model)
 
     if (output) {
-        const filePathFull = path.join(dir, filePathRelative);
-        const summaryFilePath = path.join(filePathFull + '.ai.txt');
+        const summaryFilePath = path.join(filePathRelative + '.ai.txt');
         const summaryFileContent = `File Path: ${filePathRelative}\nSummary:\n${output}`
         fs.writeFileSync(summaryFilePath, summaryFileContent);
         const timestamp = new Date().toISOString();


### PR DESCRIPTION
Task: When I update the summary files, I get a full path, we should use a relative path always from CODE_DIR.
Add test coverage on some of these functions that decide on the paths.
 
 Solves issue #80