### PR TITLE
Minimum node version 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Task: Create a diagram explaining what this project and the process
 ## 🛠️ Installation
 
 1. Clone the repository: `git clone https://github.com/fjrdomingues/autopilot.git`
-2. Do `cd autopilot` to install dependencies: `npm install`
+2. Do `cd autopilot` to install dependencies: `npm ci`
 3. Create the `.env` file and set up the environment variables:
    1. Copy the .env.template file to .env: `cp .env.template .env`
    2. Set up an OpenAI API key and file with the key: `OPENAI_API_KEY=<your-api-key>`. [Create openAI API key](https://platform.openai.com/account/api-keys)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,9 @@
       },
       "devDependencies": {
         "npm-run-all": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
We already got multiple support requests that seem like too low node versions. This just produces a warning https://github.com/fjrdomingues/autopilot/issues/124
https://github.com/fjrdomingues/autopilot/issues/145

While I'm not sure what's the minimum version that would work, sounds like some sub-version of 16, meaning some version 16 would be broken. 
I'm currently testing with `v18.15.0` and I've tested once with the newest on dockerhub 19.X