### PR TITLE
refactor getGitDiff

### DIFF
--- a/modules/gitHelper.js
+++ b/modules/gitHelper.js
@@ -1,18 +1,28 @@
 const simpleGit = require('simple-git');
 
 /**
- * Prints the output of git diff to the console.
+ * Returns the output of git diff as a string.
  */
-async function printGitDiff(dir) {
+async function getGitDiff(dir) {
   try {
     const git = simpleGit(dir);
     const diff = await git.diff();
-    console.log(`Git diff output:\n${diff}`);
+    return diff;
   } catch (error) {
     console.error(`Error executing git diff: ${error}`);
+    return '';
   }
 }
 
+/**
+ * Prints the output of git diff to the console.
+ */
+async function printGitDiff(dir) {
+  const diff = await getGitDiff(dir);
+  console.log(`Git diff output:\n${diff}`);
+}
+
 module.exports = {
+    getGitDiff,
     printGitDiff
 }


### PR DESCRIPTION
While this does nothing by itself
we split the getGitDiff from printing
to later be used by a cascade code agent
