### PR TITLE
home env for OPENAI_API_KEY with interactive init

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,3 @@
-OPENAI_API_KEY=<your-api-key>
 # Path to your code, defaults to itself.
 # Even if you are on windows this is POSIX style path.
 # For example C:\Users\user\code\project

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ Note: This project is currently operating autonomously on a server. Whenever an 
 2. Do `cd autopilot` to install dependencies: `npm ci`
 3. Create the `.env` file and set up the environment variables:
    1. Copy the .env.template file to .env: `cp .env.template .env`
-   2. Set up an OpenAI API key and file with the key: `OPENAI_API_KEY=<your-api-key>`. [Create openAI API key](https://platform.openai.com/account/api-keys)
-   3. Set the path to your code `CODE_DIR=<path-to-your-code>` (or use `-d path-to-your-code` later)
-   4. Update `IGNORE_LIST=node_modules,coverage,public,__tests__`
-   5. Update `FILE_EXTENSIONS_TO_PROCESS=.js,.tsx,.ts,.jsx`
+   2. Set the path to your code `CODE_DIR=<path-to-your-code>` (or use `-d path-to-your-code` later)
+   3. Update `IGNORE_LIST=node_modules,coverage,public,__tests__`
+   4. Update `FILE_EXTENSIONS_TO_PROCESS=.js,.tsx,.ts,.jsx`
    
 ## Running
 * `node ui -t "YOUR_TASK"` - is the easiest way to start.

--- a/agents/getFiles.test.js
+++ b/agents/getFiles.test.js
@@ -1,6 +1,8 @@
 const getRelevantFiles = require('./getFiles');
+const dotenv = require('dotenv');
 
-require('dotenv').config();
+dotenv.config();
+dotenv.config({ path: path.posix.join(os.homedir(), '.autopilot', '.env') });
 
 describe('getRelevantFiles', () => {
   const summaries = `

--- a/modules/fsInput.js
+++ b/modules/fsInput.js
@@ -1,11 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-require('dotenv').config();
 const hashFile = require('./hashing');
 const { countTokens } = require('./tokenHelper');
 
-const ignoreList = process.env.IGNORE_LIST.split(',');
-const fileExtensionsToProcess = process.env.FILE_EXTENSIONS_TO_PROCESS.split(',');
 
 /**
  * Recursively scans the directory specified by 'dir', searching for project files.
@@ -17,6 +14,9 @@ const fileExtensionsToProcess = process.env.FILE_EXTENSIONS_TO_PROCESS.split(','
  * @returns {string[]} An array of absolute file paths for all project files found.
 */
 function getFilePaths(dir) {
+	const ignoreList = process.env.IGNORE_LIST.split(',');
+	const fileExtensionsToProcess = process.env.FILE_EXTENSIONS_TO_PROCESS.split(',');
+
 	const files = fs.readdirSync(dir);
 	const projectFiles = [];
 

--- a/modules/gpt.js
+++ b/modules/gpt.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk');
-require('dotenv').config()
 const { Configuration, OpenAIApi } = require("openai");
 const {saveLog} = require('./fsOutput');
 

--- a/modules/init.js
+++ b/modules/init.js
@@ -3,34 +3,70 @@ const { createDB } = require('./db');
 const fs = require('fs');
 const { codeBaseFullIndex, codeBaseFullIndexInteractive } = require('./codeBase');
 const { getCodeBaseAutopilotDirectory } = require('./autopilotConfig');
+const chalk = require('chalk');
+const openAIApiKeyLength = 51;
+
+/**
+ * 
+ * @returns {Promise<string>} OpenAIKey
+ */
+async function askForOpenAIKey(){
+  const prompts = require('prompts');
+
+  const openAIApiKey = await prompts({
+    type: 'password',
+    name: 'value',
+    require: true,
+    message: 'OpenAIKey (https://platform.openai.com/account/api-keys)',
+    validate: value => value.length == openAIApiKeyLength ? true : 'Please enter an OpenAIKey'
+  });
+  return openAIApiKey.value;
+}
 
 /**
  *
  * @param {string} codeBaseDirectory
  */
 async function initCodeBase(codeBaseDirectory, interactive){
-    model = process.env.INDEXER_MODEL;
-    // Create directory `__CODEBASE__/.autopilot`
-    codeBaseAutopilotDirectory = getCodeBaseAutopilotDirectory(codeBaseDirectory);
-
-    if (!fs.existsSync(codeBaseAutopilotDirectory)){
-        fs.mkdirSync(codeBaseAutopilotDirectory);
+  if (!process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY.length < openAIApiKeyLength) {
+    const os = require('os');
+    const openAIApiKey = await askForOpenAIKey();
+    const homeAutopilotDirectory = path.join(os.homedir(), '.autopilot');
+    if (!fs.existsSync(homeAutopilotDirectory)){
+      fs.mkdirSync(homeAutopilotDirectory);
     }
+    const homeEnvPath = path.join(homeAutopilotDirectory, '.env');
+    const homeEnvContent = `OPENAI_API_KEY=${openAIApiKey}`;
+    
+    fs.writeFileSync(homeEnvPath, homeEnvContent);
+    console.log(chalk.green(`OpenAIKey saved to ${homeEnvPath}`));
 
-    // Create config file `__CODEBASE__/.autopilot/config.json`
-    // TODO: Refactor include/exclude lists into codebase config file
+    const dotenv = require('dotenv');
+    dotenv.config({ path: path.posix.join(os.homedir(), '.autopilot', '.env') });    
+  }
 
-    const { getDBFilePath } = require('./db');
-    // Bootstrap DB
-    if (!fs.existsSync(getDBFilePath(codeBaseDirectory))){
-        createDB(codeBaseDirectory);
-        // Trigger codeBase indexing
-        if (interactive){
-            await codeBaseFullIndexInteractive(codeBaseDirectory, model);
-        } else {
-            await codeBaseFullIndex(codeBaseDirectory);
-        }
+  model = process.env.INDEXER_MODEL;
+  // Create directory `__CODEBASE__/.autopilot`
+  codeBaseAutopilotDirectory = getCodeBaseAutopilotDirectory(codeBaseDirectory);
+
+  if (!fs.existsSync(codeBaseAutopilotDirectory)){
+    fs.mkdirSync(codeBaseAutopilotDirectory);
+  }
+
+  // Create config file `__CODEBASE__/.autopilot/config.json`
+  // TODO: Refactor include/exclude lists into codebase config file
+
+  const { getDBFilePath } = require('./db');
+  // Bootstrap DB
+  if (!fs.existsSync(getDBFilePath(codeBaseDirectory))){
+    createDB(codeBaseDirectory);
+    // Trigger codeBase indexing
+    if (interactive){
+      await codeBaseFullIndexInteractive(codeBaseDirectory, model);
+    } else {
+      await codeBaseFullIndex(codeBaseDirectory);
     }
+  }
 }
 
 module.exports = { initCodeBase }

--- a/modules/interactiveTask.js
+++ b/modules/interactiveTask.js
@@ -29,12 +29,12 @@ async function getTaskInput() {
   const prompts = require('prompts');
 
   const response = await prompts({
-     type: 'text',
-     name: 'task',
-     message: 'Please enter your TASK (multiline supported):',
-     multiline: true,
-       validate: value => value.length > 0 ? true : 'Please enter a task'
-   });
+    type: 'text',
+    name: 'task',
+    message: 'Please enter your TASK (multiline supported):',
+    multiline: true,
+    validate: value => value.length > 0 ? true : 'Please enter a task'
+  });
 
   return response.task;
 }

--- a/modules/model.js
+++ b/modules/model.js
@@ -11,6 +11,9 @@ const { OpenAI } = require('langchain/llms');
 function getModel(modelType){
     let model
     if (['gpt-3.5-turbo', 'gpt-4'].includes(modelType)) {
+        if (!process.env.OPENAI_API_KEY) {
+            throw new Error('OPENAI_API_KEY not found.');
+        }
         model = new OpenAI({ 
             modelName: modelType,
             maxTokens: parseInt(process.env.OPENAI_MAX_TOKEN_REPLY),
@@ -26,4 +29,4 @@ function getModel(modelType){
     return model
 }
 
-module.exports = { getModel }
+module.exports = { getModel };

--- a/modules/summaries.js
+++ b/modules/summaries.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 const { countTokens } = require('./tokenHelper')
 const chalk = require('chalk');
 const path = require('path');
@@ -6,8 +5,14 @@ const { parseFileContent } = require('./fsInput');
 const { getDB, insertOrUpdateFile } = require('./db');
 
 const summaryStringDelimiter = "\n---\n";
-const maxTokenSingleFile = process.env.MAX_TOKEN_COUNT_SINGLE_FILE;
-const maxSummaryTokenCount = process.env.MAX_TOKEN_COUNT_SUMMARIES_CHUNK;
+
+function getMaxTokenSingleFile(){
+  return process.env.MAX_TOKEN_COUNT_SINGLE_FILE;
+}
+
+function getMaxSummaryTokenCount(){
+  return process.env.MAX_TOKEN_COUNT_SUMMARIES_CHUNK;
+}
 
 const types = {
   FileObject: {
@@ -113,7 +118,9 @@ async function getSummaries(codeBaseDirectory){
  * @param {string} fileContent - The content of the file being processed.
  */
 async function generateAndWriteFileSummary(codeBaseDirectory, filePathRelative, fileContent) {
+  const maxTokenSingleFile = getMaxTokenSingleFile();
   const { fileSummary } = require('../agents/indexer');
+  
 
   const filePathFull = path.join(codeBaseDirectory, filePathRelative);
   const parsedFile = parseFileContent(codeBaseDirectory, filePathFull, fileContent);
@@ -162,6 +169,6 @@ module.exports = {
     types,
     getSummaries,
     chunkSummaries,
-    maxSummaryTokenCount,
+    getMaxSummaryTokenCount,
     generateAndWriteFileSummary
 }


### PR DESCRIPTION
OPENAI_API_KEY would be looked for and if doesn't exist prompt the user for one, writing it to a homedir/.autopilot/.env file with note to the user.

* Refactor where and when we load the env files and how/when we access the `process.env.` variables

https://github.com/fjrdomingues/autopilot/issues/163